### PR TITLE
Enable output buffering in 8.1-fpm-v3 image

### DIFF
--- a/8.1-fpm-v3/local.ini
+++ b/8.1-fpm-v3/local.ini
@@ -5,3 +5,4 @@ max_execution_time = 300
 max_input_time = 1000
 memory_limit = 2000M
 allow_url_fopen = true
+output_buffering = On


### PR DESCRIPTION
- add 'output_buffering = On' config to local.ini