### PR TITLE
"User" instruction typo in Dockerfiles

### DIFF
--- a/7.3.6-fpm-v1/Dockerfile
+++ b/7.3.6-fpm-v1/Dockerfile
@@ -22,4 +22,4 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.3.6-fpm-v2/Dockerfile
+++ b/7.3.6-fpm-v2/Dockerfile
@@ -26,4 +26,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.3.6-fpm-v3/Dockerfile
+++ b/7.3.6-fpm-v3/Dockerfile
@@ -27,4 +27,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.3.7-fpm-v1/Dockerfile
+++ b/7.3.7-fpm-v1/Dockerfile
@@ -26,4 +26,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-composer-v1/Dockerfile
+++ b/7.4-fpm-composer-v1/Dockerfile
@@ -39,4 +39,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-composer-v2/Dockerfile
+++ b/7.4-fpm-composer-v2/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-v1/Dockerfile
+++ b/7.4-fpm-v1/Dockerfile
@@ -29,4 +29,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-v2/Dockerfile
+++ b/7.4-fpm-v2/Dockerfile
@@ -31,4 +31,4 @@ RUN docker-php-ext-configure intl \
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-v3.1/Dockerfile
+++ b/7.4-fpm-v3.1/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-fpm-v3/Dockerfile
+++ b/7.4-fpm-v3/Dockerfile
@@ -42,4 +42,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7.4-rc-fpm-v1/Dockerfile
+++ b/7.4-rc-fpm-v1/Dockerfile
@@ -26,4 +26,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -34,4 +34,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.0-fpm-v1/Dockerfile
+++ b/8.0-fpm-v1/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.0-fpm-v2/Dockerfile
+++ b/8.0-fpm-v2/Dockerfile
@@ -45,4 +45,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.0-fpm-v3/Dockerfile
+++ b/8.0-fpm-v3/Dockerfile
@@ -49,4 +49,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-fpm-v1/Dockerfile
+++ b/8.1-fpm-v1/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-fpm-v2/Dockerfile
+++ b/8.1-fpm-v2/Dockerfile
@@ -45,4 +45,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-fpm-v3/Dockerfile
+++ b/8.1-fpm-v3/Dockerfile
@@ -49,4 +49,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-rc-fpm-v1.1/Dockerfile
+++ b/8.1-rc-fpm-v1.1/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-rc-fpm-v1/Dockerfile
+++ b/8.1-rc-fpm-v1/Dockerfile
@@ -38,4 +38,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.1-rc-fpm-v2/Dockerfile
+++ b/8.1-rc-fpm-v2/Dockerfile
@@ -44,4 +44,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.2-fpm-v1/Dockerfile
+++ b/8.2-fpm-v1/Dockerfile
@@ -43,4 +43,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.2-fpm-v2/Dockerfile
+++ b/8.2-fpm-v2/Dockerfile
@@ -45,4 +45,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user

--- a/8.2-fpm-v3/Dockerfile
+++ b/8.2-fpm-v3/Dockerfile
@@ -49,4 +49,4 @@ COPY www.conf /usr/local/etc/php-fpm.d/www.conf
 RUN groupadd -r phpusers && useradd -r -g phpusers user
 
 # Use the USER instruction to switch to the new user
-USER myuser
+USER user


### PR DESCRIPTION
- fix issues with user Dockerfile instructions